### PR TITLE
Fix esp-open-sdk image build with latest toolchain

### DIFF
--- a/esp-open-sdk/Dockerfile
+++ b/esp-open-sdk/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:jessie
 
 COPY *.sh /build/
-ENV COMMIT 19bd6df742e2a437b46eb69eb85e597135ecce8b
 
 RUN groupadd -g 1000 docker && useradd docker -u 1000 -g 1000 -s /bin/bash --no-create-home
 
+ENV VENDOR_SDK="1.5.4"
 ENV RUN_PACKAGES="make python python-serial"
-ENV BUILD_PACKAGES="unrar autoconf automake libtool gcc g++ gperf flex bison texinfo gawk libncurses5-dev libexpat1-dev git ca-certificates wget bzip2 patch libtool-bin unzip"
+ENV BUILD_PACKAGES="unrar autoconf automake libtool gcc g++ gperf flex bison texinfo gawk libncurses5-dev libexpat1-dev git ca-certificates wget bzip2 patch libtool-bin unzip help2man"
 
 RUN /build/prepare.sh && chown -R docker:docker /build && su docker -c "/build/build.sh" && mkdir -p /opt/esp-open-sdk/ && mv /build/esp-open-sdk/xtensa-lx106-elf/ /opt/esp-open-sdk/ && /build/cleanup.sh
 

--- a/esp-open-sdk/build.sh
+++ b/esp-open-sdk/build.sh
@@ -3,5 +3,5 @@
 git clone --recursive https://github.com/pfalcon/esp-open-sdk.git /build/esp-open-sdk
 
 pushd /build/esp-open-sdk
-make STANDALONE=y
+make STANDALONE=y VENDOR_SDK=$VENDOR_SDK
 popd


### PR DESCRIPTION
Hi,

I've fixed the image for latest toolchain — your last build has failed — https://hub.docker.com/r/simonvanderveldt/esp-open-sdk/builds/bcseynvsguzarxmnwdnncbh/.
